### PR TITLE
docs: remove chainrules-linalg, merge matrix AD into tenferro-linalg

### DIFF
--- a/docs/design/tenferro_unified_tensor_backend.md
+++ b/docs/design/tenferro_unified_tensor_backend.md
@@ -124,10 +124,7 @@ These have significant overlap (3 einsum implementations, 3 scalar trait definit
 │   pullback(), hvp() (forward-over-reverse HVP)               │
 │   Gradients<V>, PullbackPlan<V>, HvpResult<V>                │
 │                                                              │
-│   Matrix Decomposition AD (chainrules-linalg)           [POC]    │
-│   Matrix-level SVD, QR, LU, eigen + AD rules (rrule/frule)  │
-│   2D matrix operations only (no tensor dim permutation)      │
-│   May use nalgebra/mdarray-linalg/faer internally            │
+│                                                              │
 └──────────────────────┬──────────────────────────────────────┘
                        │
 ┌──────────────────────▼──────────────────────────────────────┐
@@ -229,11 +226,11 @@ tenferro-rs/ (workspace) ── 11 POC crates ───────────�
 │                        #   SVD, QR, LU, eigen with left/right dim indices
 │                        #   Matricize → decompose → unmatricize pattern
 │                        #   SvdOptions (max_rank, cutoff) for truncated SVD
-│                        #   Tensor-level AD: handles dim permutation, then
-│                        #     delegates to chainrules-linalg for 2D matrix AD rules
+│                        #   Tensor-level AD: handles dim permutation + 2D matrix AD
 │                        #   Full AD: tracked_*, dual_*, *_rrule, *_frule
+│                        #   GPU: cuSOLVER/rocSOLVER via tenferro-device
 │                        #   Depends on: tenferro-device, tenferro-algebra,
-│                        #     tenferro-tensor, chainrules, chainrules-linalg
+│                        #     tenferro-tensor, chainrules
 │
 ├── tenferro-capi        # C-API (FFI) for Julia/Python
 │                        #   Opaque TfeTensorF64 handle, tfe_status_t error codes
@@ -301,12 +298,8 @@ tenferro-rs/ (workspace) ── 11 POC crates ───────────�
     │                        #   Re-exports all of chainrules-core
     │                        #   Depends on: chainrules-core
     │
-    └── chainrules-linalg        # Matrix-level decompositions + AD rules
-                             #   SVD, QR, LU, eigen for 2D matrices
-                             #   Matrix-level rrule/frule (Mathieu 2019 et al.)
-                             #   No tensor dim permutation (that's tenferro-linalg)
-                             #   May use nalgebra/mdarray-linalg/faer internally
-                             #   Depends on: chainrules-core
+    └── (no chainrules-linalg: matrix-level AD is handled
+          directly by tenferro-linalg for GPU compatibility)
 ```
 
 ### Future Crates (not in POC)
@@ -347,11 +340,9 @@ tenferro-rs workspace:
 │                                                              │
 │  chainrules-core              (← thiserror)                  │
 │      │                                                       │
-│      ├───────────────┐                                       │
-│      ↓               ↓                                       │
-│  chainrules      chainrules-linalg                               │
-│   (← chainrules-core) (← chainrules-core;                    │
-│                         optionally nalgebra/faer)             │
+│      ↓                                                       │
+│  chainrules                                                  │
+│   (← chainrules-core)                                        │
 │                                                              │
 └──────────────────────────────────────────────────────────────┘
     │
@@ -379,8 +370,7 @@ tenferro-rs workspace:
 │        (← tenferro-algebra, ← chainrules)                    │
 │      tenferro-linalg                                         │
 │        (← tenferro-algebra, ← chainrules,                    │
-│         ← tenferro-tensor, ← tenferro-device,                │
-│         ← chainrules-linalg)                                     │
+│         ← tenferro-tensor, ← tenferro-device)                │
 │             │                                                │
 │             ↓                                                │
 │      tenferro-capi                                           │
@@ -410,7 +400,6 @@ tenferro-rs workspace:
 ```
 ┌─ extern/ (general-purpose) ──────────────────────────────────┐
 │  chainrules-core → chainrules                                │
-│                  → chainrules-linalg (2D matrix SVD/QR + AD)     │
 └──────────────────────────────────────────────────────────────┘
     │
 ┌─ core ───────────────────────────────────────────────────────┐
@@ -423,7 +412,7 @@ tenferro-rs workspace:
 │      └──────┬─────────┘                                      │
 │             ↓                                                │
 │  tenferro-einsum (← chainrules)                              │
-│  tenferro-linalg (← chainrules, ← chainrules-linalg)            │
+│  tenferro-linalg (← chainrules)                                │
 │             │                                                │
 │             ↓                                                │
 │  tenferro-capi                                               │
@@ -466,8 +455,7 @@ burn-tenferro ← tenferro-tensor, burn-backend
 | tenferro-algebra | omeinsum-rs (Algebra traits) | Standalone crate for Semiring/tropical types [future] |
 | chainrules-core | **New** (POC) | Core AD traits: Differentiable, ReverseRule, ForwardRule (like Julia ChainRulesCore.jl) |
 | chainrules | **New** (POC) | AD engine: Tape, TrackedTensor, DualTensor, pullback, hvp (like Julia Zygote.jl) |
-| chainrules-linalg | ndtensors-rs (linalg AD) | **POC** API skeleton: matrix-level SVD/QR/LU/eigen + AD rules (rrule/frule). May use nalgebra/faer internally |
-| tenferro-linalg | ndtensors-rs (linalg) | **POC** API skeleton: tensor-level SVD/QR/LU/eigen (matricize/unmatricize + dim permutation AD). Delegates to chainrules-linalg for 2D AD |
+| tenferro-linalg | ndtensors-rs (linalg + linalg AD) | **POC** API skeleton: tensor-level SVD/QR/LU/eigen (matricize/unmatricize + dim permutation AD). Includes 2D matrix-level AD rules internally (Mathieu 2019). GPU: cuSOLVER/rocSOLVER |
 | tenferro-capi | ndtensors-rs (capi) + tensor4all-rs (capi) | **POC** API skeleton: einsum + SVD, f64 only, stateless rrule/frule (14 functions) |
 | tenferro-tropical | omeinsum-rs (algebra) | **POC** API skeleton: MaxPlus, MinPlus, MaxMul scalars + algebra markers + TensorPrims impls + ArgmaxTracker |
 | tenferro-tropical-capi | **New** (POC) | C-API for tropical einsum: 9 FFI functions (3 algebras × einsum/rrule/frule), reuses TfeTensorF64 from tenferro-capi |
@@ -496,7 +484,7 @@ burn-tenferro ← tenferro-tensor, burn-backend
 
 > **Detailed API designs**: See [tenferro Design](https://github.com/tensor4all/tenferro-rs/blob/main/docs/design/tenferro_design.md) in tenferro-rs for full per-crate API designs including code examples.
 
-The POC implements twelve crates:
+The POC implements eleven crates:
 
 - **tenferro-device** — `LogicalMemorySpace` (MainMemory, PinnedMemory, GpuMemory, ManagedMemory) + `ComputeDevice` enums, `OpKind`, `preferred_compute_devices()`, shared `Error`/`Result` types. DLPack-aligned device model.
 - **tenferro-algebra** — `HasAlgebra` trait (maps scalar T → algebra A), `Semiring` trait, `Standard` type for standard arithmetic. `Scalar` trait (blanket impl, replaces strided-traits' `Scalar`). `Conjugate` trait for complex conjugation.
@@ -505,8 +493,7 @@ The POC implements twelve crates:
 - **tenferro-prims** — `TensorPrims<A>` trait with cuTENSOR-compatible plan-based execution. Core ops (batched_gemm, reduce, trace, permute, anti_trace, anti_diag) + dynamically-queried extended ops (contract, elementwise_mul). `CpuBackend` implements `TensorPrims<Standard>`.
 - **tenferro-tensor** — `Tensor<T>` with `DataBuffer<T>` (opaque struct: Owned `Vec<T>` or External with DLPack release callback), shape/strides, zero-copy view ops (permute, broadcast, diagonal, reshape), `CompletionEvent` for async execution, `TensorView<'a, T>` for borrowed views, consuming variants (`into_contiguous`, `into_conj`). Implements `Differentiable` for `Tensor<T>`. No strided-rs dependency.
 - **tenferro-einsum** — High-level einsum on `Tensor<T>` with string notation, parenthesized contraction order, `Subscripts`, `ContractionTree`. Nine API functions: allocating, accumulating (`_into` with alpha/beta), and consuming (`_owned` for buffer reuse). Einsum AD rules: `tracked_einsum`, `dual_einsum`, `einsum_rrule`, `einsum_frule`, `einsum_hvp`.
-- **chainrules-linalg** — Matrix-level (2D) SVD, QR, LU, eigendecomposition with AD rules (`mat_svd_rrule`/`mat_svd_frule`, etc.). Uses zero-dependency `MatrixView<'a, T>` interface (`&[T]` + shape + strides). Pure matrix math (Mathieu 2019 et al.), no tensor dimension handling. Depends only on `chainrules-core`. General-purpose, no tenferro dependency.
-- **tenferro-linalg** — Tensor-level SVD, QR, LU, eigendecomposition with left/right dimension indices. Handles matricize → decompose → unmatricize pattern and tensor-level AD (dim permutation). Delegates to `chainrules-linalg` for 2D matrix AD rules. Full tensor AD: `tracked_svd`, `dual_svd`, `svd_rrule`, `svd_frule`, and same for QR/LU/eigen.
+- **tenferro-linalg** — Tensor-level SVD, QR, LU, eigendecomposition with left/right dimension indices. Handles matricize → decompose → unmatricize pattern, 2D matrix-level AD rules (Mathieu 2019 et al.), and tensor-level AD (dim permutation). GPU: cuSOLVER/rocSOLVER. Full tensor AD: `tracked_svd`, `dual_svd`, `svd_rrule`, `svd_frule`, and same for QR/LU/eigen.
 - **tenferro-capi** — C-API (FFI) for Julia/Python: opaque `TfeTensorF64` handle, `tfe_status_t` error codes. 16 functions: tensor lifecycle (8) + DLPack interop (2: `tfe_tensor_f64_to_dlpack`, `tfe_tensor_f64_from_dlpack`) + einsum (3) + SVD (3). DLPack v1.0 zero-copy tensor exchange (CPU/CUDA/ROCm/managed memory). Stateless `rrule`/`frule` only (no tape exposure). f64 only in POC phase. Produces rlib in addition to cdylib/staticlib, enabling type sharing with extension capi crates.
 - **tenferro-tropical-capi** — C-API (FFI) for tropical einsum: extends `tenferro-capi` with tropical-specific functions. 9 functions: 3 algebras (MaxPlus, MinPlus, MaxMul) × 3 functions (einsum, rrule, frule). Reuses `TfeTensorF64` handles since `MaxPlus<f64>` is `#[repr(transparent)]` (same memory layout as f64). Algebra is selected by function name (`tfe_tropical_einsum_maxplus_f64`, etc.), not by handle type. Produces a separate `.so` from `tenferro-capi`; C consumers load both.
 - **tenferro-tropical** — Tropical semiring tensor operations: `MaxPlus<T>` (⊕=max, ⊗=+), `MinPlus<T>` (⊕=min, ⊗=+), `MaxMul<T>` (⊕=max, ⊗=×) scalar wrappers with `#[repr(transparent)]`. Algebra markers (`MaxPlusAlgebra`, `MinPlusAlgebra`, `MaxMulAlgebra`) with `HasAlgebra` and `Semiring` impls (f64 only for POC). `TensorPrims` impls for `CpuBackend` (all three algebras, orphan rule compatible). `TropicalPlan<T>` for plan-based execution. `ArgmaxTracker` for tropical backward pass (AD).
@@ -552,54 +539,32 @@ Being a workspace crate with locally-defined algebra markers proves that
 
 ---
 
-## chainrules-linalg + tenferro-linalg (POC exists)
-
-Matrix decompositions are split into two layers:
-
-### chainrules-linalg (extern/ — general-purpose, no tenferro dependency)
-
-> **POC API skeleton** for matrix-level (2D) decompositions + AD rules.
-
-Provides pure matrix math: SVD, QR, LU, eigendecomposition for 2D matrices,
-plus their AD rules (rrule/frule) based on Mathieu (2019) et al.
-
-**Interface**: Zero-dependency `MatrixView<'a, T>` (`&[T]` + nrows/ncols + row_stride/col_stride).
-**Result types**: `MatSvdResult<T>`, `MatQrResult<T>`, `MatLuResult<T>`, `MatEigenResult<T>` (owned, `Vec<T>`).
-**Cotangent types**: `MatSvdCotangent<'a, T>`, `MatQrCotangent<'a, T>`, etc.
-**Primary functions**: `mat_svd`, `mat_qr`, `mat_lu`, `mat_eigen`.
-**AD rules**: `mat_svd_rrule`/`mat_svd_frule`, `mat_qr_rrule`/`mat_qr_frule`, etc.
-**SVD truncation**: `MatSvdOptions` (`max_rank`, `cutoff`).
-
-- No tensor dimension handling (no matricize/unmatricize)
-- May use nalgebra, mdarray-linalg, or faer internally (not required in POC)
-- Depends on: `chainrules-core` only
-- Reusable by any project that needs matrix AD, not just tenferro
-
-### tenferro-linalg (core — tensor-level wrapper)
+## tenferro-linalg (POC exists)
 
 > **POC API skeleton exists** with tensor-level SVD, QR, LU, eigen + full AD rules.
 
+Provides both tensor-level decompositions and 2D matrix-level AD rules in a
+single crate. This unified design enables GPU support (cuSOLVER/rocSOLVER)
+for both decompositions and AD rule computations via `tenferro-device`.
+
 The user specifies which dimensions form "left" (row) and "right" (column)
-sides. Internally: matricize → call chainrules-linalg → unmatricize.
+sides. Internally: matricize → decompose (+ AD math, Mathieu 2019) → unmatricize.
 
 **Primary functions**: `svd`, `qr`, `lu`, `eigen`.
 **Result types**: `SvdResult`, `QrResult`, `LuResult`, `EigenResult`.
 **SVD truncation**: `SvdOptions` (`max_rank`, `cutoff`).
 
-**Tensor-level AD rules** (all POC API skeletons):
+**AD rules** (all POC API skeletons):
 - Reverse-mode: `tracked_svd`, `tracked_qr`, `tracked_lu`, `tracked_eigen`
 - Forward-mode: `dual_svd`, `dual_qr`, `dual_lu`, `dual_eigen`
 - Stateless rules: `svd_rrule`/`svd_frule`, `qr_rrule`/`qr_frule`,
   `lu_rrule`/`lu_frule`, `eigen_rrule`/`eigen_frule`
 
-Tensor-level AD handles dimension permutation (matricize/unmatricize),
-then delegates to `chainrules-linalg` for the 2D matrix AD rules.
-
 **GPU path**: cuSOLVER/rocSOLVER via runtime-loaded vendor library (same dlopen pattern).
 
 **Existing code to reuse**:
 - `ndtensors-rs/crates/ndtensors/src/backend/faer_interop.rs` -- faer bridge pattern
-- `ndtensors-rs/crates/ndtensors/src/linalg/` -- SVD, QR implementations
+- `ndtensors-rs/crates/ndtensors/src/linalg/` -- SVD, QR implementations + AD rules
 
 ---
 
@@ -672,9 +637,8 @@ pub struct HvpResult<V: Differentiable> { gradients: Gradients<V>, hvp: Gradient
 
 AD rules live in their operation crates, not in chainrules:
 
-- **chainrules-linalg** (extern/): `mat_svd_rrule`/`mat_svd_frule` (and same for QR, LU, eigen) — 2D matrix-level AD
 - **tenferro-einsum**: `tracked_einsum`, `dual_einsum`, `einsum_rrule`, `einsum_frule`, `einsum_hvp`
-- **tenferro-linalg**: `tracked_svd`/`dual_svd`/`svd_rrule`/`svd_frule` (and same for QR, LU, eigen) — tensor-level AD (delegates to chainrules-linalg for 2D rules)
+- **tenferro-linalg**: `tracked_svd`/`dual_svd`/`svd_rrule`/`svd_frule` (and same for QR, LU, eigen) — tensor-level + 2D matrix-level AD (Mathieu 2019)
 - **tenferro-capi**: Exposes stateless `rrule`/`frule` only via FFI
 
 ### Contraction VJP/JVP
@@ -1186,12 +1150,10 @@ cd tenferro-rs && cargo test --workspace
 - HVP correctness (forward-over-reverse)
 - Complex-valued gradient test (Wirtinger calculus)
 
-**chainrules-linalg**:
+**tenferro-linalg**:
 - Matrix-level SVD/QR/LU/eigen correctness (2D matrices)
 - Matrix-level AD rule correctness: finite-difference vs rrule/frule
 - Complex matrix SVD test (Wirtinger calculus)
-
-**tenferro-linalg**:
 - Tensor-level SVD/QR with dimension permutation (matricize/unmatricize)
 - Cross-validate results against ndtensors-rs
 - Tensor-level AD correctness: dim permutation handling in rrule/frule
@@ -1232,8 +1194,8 @@ cd tenferro-rs && cargo test --workspace
 | Backend trait | `omeinsum-rs/src/backend/traits.rs` | **Absorbed** into tenferro-prims (evolved into TensorPrims) |
 | cuTENSOR wrapper | `omeinsum-rs/src/backend/cuda/cutensor/` | **Absorbed** into tenferro-device (GPU vtable) [future] |
 | PlanCache | `omeinsum-rs/src/backend/cuda/cutensor/contract.rs` | **Absorbed** into tenferro-device [future] |
-| faer bridge | `ndtensors-rs/.../faer_interop.rs` | chainrules-linalg (may use faer internally) |
-| Matrix AD rules | `ndtensors-rs/.../linalg/` | chainrules-linalg: matrix-level rrule/frule for SVD/QR/LU/eigen |
+| faer bridge | `ndtensors-rs/.../faer_interop.rs` | tenferro-linalg (may use faer internally for CPU path) |
+| Matrix AD rules | `ndtensors-rs/.../linalg/` | tenferro-linalg: matrix-level rrule/frule for SVD/QR/LU/eigen |
 | contract_vjp | `ndtensors-rs/.../contract/naive.rs` | tenferro-einsum einsum_rrule (POC API exists) |
 | TrackedTensor | `ndtensors-rs/.../autodiff/tensor.rs` | chainrules TrackedTensor (POC API exists) |
 | C API patterns | `tensor4all-rs/crates/tensor4all-capi/src/` | tenferro-capi (POC: 16 functions) + tenferro-tropical-capi (POC: 9 functions) |


### PR DESCRIPTION
## Summary
- Remove all `chainrules-linalg` references from design document
- Update tenferro-linalg description to include 2D matrix-level AD (Mathieu 2019)
- Update dependency graphs (POC and future) to remove chainrules-linalg
- Update crate count: 12 → 11

## Test plan
- [x] No `chainrules-linalg` references remain (except explanatory note)

Generated with [Claude Code](https://claude.com/claude-code)